### PR TITLE
md to python script

### DIFF
--- a/scripts/md2py.py
+++ b/scripts/md2py.py
@@ -1,0 +1,46 @@
+import argparse
+from pathlib import Path
+import subprocess
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument(
+    "--md_filepath", 
+    default="./test_md.md", 
+    help="Path to target markdown file", 
+    type=str
+)
+
+def main(md_filepath):
+    """
+    Opens a markdown file, collects python code cells in a python script and 
+    executes the python script. 
+    """
+
+    file = open(md_filepath)
+    script_name = f"{str(Path(md_filepath).with_suffix(''))}.py"
+    content = file.readlines()
+
+    copying = False
+
+    # collecting python cells into a python script
+    with open(f'{script_name}', 'w') as script:
+        for i, line in enumerate(content):
+        
+            if "```python" in line:
+                copying = True
+                continue
+
+            elif "```" in line:
+                copying = False
+                continue
+
+            if copying:
+                script.write(line)
+    
+    # executing the python script
+    subprocess.call(f'python {script_name}', shell=True)
+
+if __name__ == "__main__":
+    args = vars(parser.parse_args())
+    main(**args)

--- a/scripts/md2py.py
+++ b/scripts/md2py.py
@@ -25,7 +25,7 @@ def main(md_filepath):
 
     # collecting python cells into a python script
     with open(f'{script_name}', 'w') as script:
-        for i, line in enumerate(content):
+        for line in content:
         
             if "```python" in line:
                 copying = True

--- a/scripts/test_md.md
+++ b/scripts/test_md.md
@@ -1,0 +1,29 @@
+#### Test file to be opened with `md2md.py` script
+
+This is normal text in markdown mode.
+The following is LaTeX in markdown mode:
+
+$$ y = f(x) $$
+
+```python
+import qibo
+from qibo import models, gates 
+qibo.set_backend('numpy')
+```
+
+Now we will write a code block defining a circuit.
+
+```python
+c = models.Circuit(1)
+c.add(gates.H(0))
+c.add(gates.M(0))
+```
+
+Finally we perform a circuit execution and calculate final state probabilities.
+
+```python
+probs = c.execute(nshots=1000).probabilities(qubits=[0])
+print(probs)
+```
+
+This is the last line of this test markdown.

--- a/scripts/test_md.py
+++ b/scripts/test_md.py
@@ -1,0 +1,8 @@
+import qibo
+from qibo import models, gates 
+qibo.set_backend('numpy')
+c = models.Circuit(1)
+c.add(gates.H(0))
+c.add(gates.M(0))
+probs = c.execute(nshots=1000).probabilities(qubits=[0])
+print(probs)


### PR DESCRIPTION
### Content of this PR

- A python script is implemented in `./scripts/md2py.py`. It takes all the python code cells from a markdown file, collects them into another python script which is then executed;
- a test of this script on a simple markdown file `test_md.md`.

### Motivation of this PR

After a discussion had with @AleCandido, I think we should change the goal of this repository. 
Personally, I like the idea to have the same convention between the tutorials in the documentation and this repo. Moreover, I think it can be better to deal with `*md, *mdx` files instead of Jupyter Notebooks for at least three reasons:
1. a markdown file is clearer to be reviewed than a Jupyter Notebook;
2. it is trivial to convert a Jupyter Notebook into a markdown file;
3. we can define a precise style for contributions: a bit more effort in writing tutorials,  but a well-organised structure.  

In this sense, it is useful to have a script like the one is here implemented: it allows us to run the code contained in each tutorial every time we modify `qibo`'s main.